### PR TITLE
Fix forward propagation in output layer

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include<iostream>
 #include<vector>
 #include<random>
+#include<algorithm>
 #include<fstream>
 #include<cmath>
 #include<iomanip>
@@ -167,6 +168,7 @@ struct olayer{
             }
             z[i] += biases[i];
         }
+        outputs = util::softmax(z);
     }
 
     std::pair<float, std::vector<float> > backward(float lr, const std::vector<float>& dL_dZ, const std::vector<float>& tl){
@@ -176,10 +178,8 @@ struct olayer{
             }
             biases[i] -= lr * dL_dZ[i];
         }
-
-        outputs = util::softmax(outputs);
-
-        return {util::cross_entropy_loss(tl, outputs), outputs};
+        float loss = util::cross_entropy_loss(tl, outputs);
+        return {loss, outputs};
     }
 };
 
@@ -292,6 +292,9 @@ class NeuralNetwork{
                         for(int j = 0; j < 128; j++){
                             dL_dZ_h[j] += dL_dZ_o[i] * output.weights[i][j];
                         }
+                    }
+                    for(int j = 0; j < 128; j++){
+                        dL_dZ_h[j] *= util::lrelu_d(hidden.z[j]);
                     }
                     hidden.backward(learning_rate, dL_dZ_h);
 


### PR DESCRIPTION
## Summary
- apply softmax during forward pass of output layer
- compute loss after weight updates
- backpropagate through hidden layer with activation derivative

## Testing
- `g++ -std=c++17 main.cpp -o /tmp/main_exec`

------
https://chatgpt.com/codex/tasks/task_e_6852c6c7383483239157fb766276b59d